### PR TITLE
Fix start command as shown in documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
 ]
 
 [project.scripts]
-mcp-anywhere = "mcp_anywhere.__main__:main"
+mcp-anywhere = "mcp_anywhere.__main__:run_cli"
 
 [tool.ruff]
 line-length = 100

--- a/src/mcp_anywhere/__main__.py
+++ b/src/mcp_anywhere/__main__.py
@@ -230,5 +230,10 @@ async def main() -> None:
         sys.exit(1)
 
 
+def run_cli() -> None:
+    """Synchronous entry point for CLI that properly handles async main."""
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
As it stands, the start command in the documentation doesn't work.

https://github.com/locomotive-agency/mcp-anywhere/blob/3732d0aab047c00966d633856781c507ffdb5157/docs/getting-started.md?plain=1#L53-L61

This is because the application requires `asyncio.run` or similar to await the `main` function, but calling the `main` function directly through the script in pyproject.toml doesn't await it. You will instead be met with the following error:

```
<coroutine object main at 0x105b305e0>
<sys>:0: RuntimeWarning: coroutine 'main' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This PR adds a non-async utility function that calls `asyncio.run` to start the application. Then the script in pyproject.toml can reference this instead.
