### PR TITLE
fix: surface missing secret files instead of silent mount skip

### DIFF
--- a/src/mcp_anywhere/core/mcp_manager.py
+++ b/src/mcp_anywhere/core/mcp_manager.py
@@ -86,6 +86,10 @@ def create_mcp_config(server: "MCPServer") -> dict[str, dict[str, Any]]:
         "init_timeout": 15,  # Add a 15-second initialization timeout
     }
 
+    logger.debug(
+        "docker run args for server %s: %s", server.name, new_config["args"]
+    )
+
     return {"new": new_config, "existing": existing_config}
 
 

--- a/src/mcp_anywhere/security/file_manager.py
+++ b/src/mcp_anywhere/security/file_manager.py
@@ -170,25 +170,45 @@ class SecureFileManager:
                 continue
 
             stored_path = server_dir / secret_file.stored_filename
-            if stored_path.exists():
-                # Decrypt file to a temporary location for container mounting
-                decrypted_content = self.retrieve_file(
-                    server_id, secret_file.stored_filename
+            if not stored_path.is_file():
+                raise FileNotFoundError(
+                    f"Secret file '{secret_file.original_filename}' for server "
+                    f"{server_id} is missing on disk at {stored_path}. The "
+                    f"database row is active but the encrypted content is gone "
+                    f"— re-upload the file to fix this."
                 )
 
-                # Create a temporary unencrypted file for container mounting
-                temp_filename = f"temp_{secret_file.stored_filename}"
-                temp_path = server_dir / temp_filename
+            # Decrypt file to a temporary location for container mounting
+            decrypted_content = self.retrieve_file(
+                server_id, secret_file.stored_filename
+            )
 
-                with open(temp_path, "wb") as f:
-                    f.write(decrypted_content)
+            # Create a temporary unencrypted file for container mounting
+            temp_filename = f"temp_{secret_file.stored_filename}"
+            temp_path = server_dir / temp_filename
 
-                os.chmod(temp_path, 0o600)
+            # Defensive: if a stale directory exists at temp_path (e.g. from a
+            # previous failed run where Docker auto-created one), remove it so
+            # the open() below produces a regular file.
+            if temp_path.is_dir():
+                shutil.rmtree(temp_path)
 
-                # Map to container path
-                container_path = self.get_container_file_path(
-                    secret_file.original_filename
+            with open(temp_path, "wb") as f:
+                f.write(decrypted_content)
+
+            os.chmod(temp_path, 0o600)
+
+            if not temp_path.is_file():
+                raise RuntimeError(
+                    f"Prepared secret file is not a regular file: {temp_path}. "
+                    f"Refusing to bind-mount it because Docker would silently "
+                    f"create a directory at the destination path."
                 )
-                container_files[str(temp_path)] = container_path
+
+            # Map to container path
+            container_path = self.get_container_file_path(
+                secret_file.original_filename
+            )
+            container_files[str(temp_path)] = container_path
 
         return container_files

--- a/tests/test_secret_file_manager.py
+++ b/tests/test_secret_file_manager.py
@@ -1,0 +1,79 @@
+"""Tests for SecureFileManager secret-file mounting behaviour."""
+
+import shutil
+from types import SimpleNamespace
+
+import pytest
+
+from mcp_anywhere.security.file_manager import SecureFileManager
+
+
+def _make_secret(stored_filename: str, original_filename: str = "creds.json"):
+    return SimpleNamespace(
+        is_active=True,
+        stored_filename=stored_filename,
+        original_filename=original_filename,
+        env_var_name="GOOGLE_CREDENTIALS_PATH",
+    )
+
+
+def test_prepare_container_files_raises_when_stored_file_missing(tmp_path):
+    """If the DB row is active but the encrypted file is gone, fail loudly."""
+    fm = SecureFileManager(storage_path=tmp_path)
+    server_id = "abc12345"
+
+    # Force-create the server dir without writing any encrypted file.
+    fm._get_server_secrets_dir(server_id)
+    secret = _make_secret(stored_filename="missing.json")
+
+    with pytest.raises(FileNotFoundError):
+        fm.prepare_container_files(server_id, [secret])
+
+
+def test_prepare_container_files_writes_regular_file(tmp_path):
+    fm = SecureFileManager(storage_path=tmp_path)
+    server_id = "abc12345"
+    stored = fm.store_file(server_id, "creds.json", b'{"hello": "world"}')
+
+    secret = _make_secret(stored_filename=stored)
+    mounts = fm.prepare_container_files(server_id, [secret])
+
+    assert len(mounts) == 1
+    [host_path] = mounts.keys()
+    assert mounts[host_path] == "/secrets/creds.json"
+
+    from pathlib import Path
+    assert Path(host_path).is_file()
+
+
+def test_prepare_container_files_replaces_stale_dir_at_temp_path(tmp_path):
+    """If a directory was left behind at temp_path, replace it with the file."""
+    fm = SecureFileManager(storage_path=tmp_path)
+    server_id = "abc12345"
+    stored = fm.store_file(server_id, "creds.json", b'{"hello": "world"}')
+
+    server_dir = fm._get_server_secrets_dir(server_id)
+    stale_dir = server_dir / f"temp_{stored}"
+    stale_dir.mkdir()
+    assert stale_dir.is_dir()
+
+    secret = _make_secret(stored_filename=stored)
+    mounts = fm.prepare_container_files(server_id, [secret])
+
+    [host_path] = mounts.keys()
+    from pathlib import Path
+    assert Path(host_path).is_file()
+
+    shutil.rmtree(server_dir)
+
+
+def test_prepare_container_files_skips_inactive(tmp_path):
+    fm = SecureFileManager(storage_path=tmp_path)
+    server_id = "abc12345"
+    stored = fm.store_file(server_id, "creds.json", b'{"hello": "world"}')
+
+    secret = _make_secret(stored_filename=stored)
+    secret.is_active = False
+
+    mounts = fm.prepare_container_files(server_id, [secret])
+    assert mounts == {}


### PR DESCRIPTION
## Summary

- `prepare_container_files` no longer silently skips when an active `MCPServerSecretFile` row's encrypted content is missing on disk. It now raises `FileNotFoundError` so the failure surfaces as a server-level error instead of producing a confusing pydantic `path_not_file` crash inside the child MCP container.
- Defensively removes any stale directory left at the temp bind-source path before writing, and asserts the prepared source is a regular file before returning the mount mapping. This stops Docker from auto-creating an empty directory at a non-existent bind source and silently mounting that directory at `/secrets/<name>.json`.
- Logs the assembled `docker run` args from `create_mcp_config` at debug level, so future mount failures can be diagnosed from the app log alone.

## Why

A user uploaded a Google Search Console credentials file to an MCP server. The file appeared in the UI but at runtime the MCP server crashed with `pydantic_core._pydantic_core.ValidationError: ... google_credentials_path Path does not point to a file [type=path_not_file, input_value='/secrets/mcp-anywhere-servers.json']`.

The env var was being injected purely from DB metadata in `_get_env_vars`, while `prepare_container_files` only added the matching `-v` mount when `stored_path.exists()` returned true. Any drift between DB state and on-disk state produced env-var-without-mount, and Docker's bind-mount-on-non-existent-source behaviour turned the destination path into a directory inside the child container.

## Test plan

- [x] `uv run --python 3.12 pytest tests/test_secret_file_manager.py` passes (4 new tests covering missing-file, happy-path, stale-directory, and inactive-row cases)
- [ ] Reviewer to verify locally: with a fresh server and uploaded secret, `docker compose exec app docker inspect mcp-<id> --format '{{json .Mounts}}'` shows `Type: bind` with a regular file as the source
- [ ] Reviewer to verify locally: deleting the encrypted file under `.data/secrets/<id>/` while leaving the DB row active surfaces a clean error in `build_error` instead of a child-container pydantic crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)