### PR TITLE
fix: translate bind sources to host paths for sibling-container deploys

### DIFF
--- a/src/mcp_anywhere/config.py
+++ b/src/mcp_anywhere/config.py
@@ -40,6 +40,19 @@ class Config:
     SECRETS_DIR = DATA_DIR / "secrets"
     SECRETS_DIR.mkdir(exist_ok=True)
 
+    # Host-side path that DATA_DIR maps to. Only relevant when MCP Anywhere
+    # runs inside a container talking to a sibling (host) docker daemon: bind
+    # mounts in spawned MCP-server containers must reference the host path of
+    # any file written under DATA_DIR, not the in-container path.
+    #
+    # Leave unset (None) when:
+    #  - MCP Anywhere runs natively on the host, or
+    #  - DinD setup where the daemon shares the app's filesystem.
+    #
+    # If unset, ContainerManager will attempt to auto-detect the mapping by
+    # inspecting its own container via the docker socket.
+    HOST_DATA_DIR = os.environ.get("HOST_DATA_DIR")
+
     # Session settings
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key-change-in-production")
     SESSION_MAX_AGE = int(os.environ.get("SESSION_MAX_AGE", "28800"))  # 8 hours default

--- a/src/mcp_anywhere/container/manager.py
+++ b/src/mcp_anywhere/container/manager.py
@@ -9,6 +9,8 @@ import json
 import os
 import re
 import shlex
+import socket
+from pathlib import Path
 from typing import Any, Optional
 
 import docker
@@ -45,6 +47,90 @@ class ContainerManager:
         self.reused_containers = set()
         # Secure file manager for handling secret files
         self.file_manager = SecureFileManager()
+        # Cache for the host-side DATA_DIR mapping (see _detect_host_data_dir).
+        self._host_data_dir_cache: Path | None | str = "unset"
+
+    def _detect_host_data_dir(self) -> Path | None:
+        """Detect the host path that DATA_DIR maps to.
+
+        When MCP Anywhere runs as a sibling container talking to the host
+        docker daemon (e.g. with /var/run/docker.sock bind-mounted in), bind
+        mounts on spawned MCP-server containers are resolved by the host
+        daemon against the host's filesystem — not the app container's. So we
+        need to translate any in-container path under DATA_DIR back to its
+        host-side path before passing it as a bind source.
+
+        Resolution order:
+        1. Explicit Config.HOST_DATA_DIR override (env var).
+        2. Auto-detect by inspecting our own container's mounts via the docker
+           socket. We find the mount whose Destination is DATA_DIR and use its
+           Source as the host path.
+        3. Return None — meaning no translation; caller passes paths through
+           as-is. This is correct for native deploys and DinD.
+        """
+        if self._host_data_dir_cache != "unset":
+            return self._host_data_dir_cache  # type: ignore[return-value]
+
+        # Explicit override always wins.
+        if Config.HOST_DATA_DIR:
+            host_path = Path(Config.HOST_DATA_DIR)
+            logger.debug("Using HOST_DATA_DIR override: %s", host_path)
+            self._host_data_dir_cache = host_path
+            return host_path
+
+        # Auto-detect via docker inspect of our own container.
+        try:
+            container_id = socket.gethostname()
+            container = self.docker_client.containers.get(container_id)
+            data_dir_str = str(Config.DATA_DIR).rstrip("/")
+            for mount in container.attrs.get("Mounts", []):
+                dest = mount.get("Destination", "").rstrip("/")
+                if dest == data_dir_str:
+                    source = mount.get("Source")
+                    if source:
+                        host_path = Path(source)
+                        logger.info(
+                            "Auto-detected host DATA_DIR mapping: %s -> %s",
+                            Config.DATA_DIR,
+                            host_path,
+                        )
+                        self._host_data_dir_cache = host_path
+                        return host_path
+            logger.debug(
+                "No bind mount found at %s in container %s; assuming native "
+                "deploy or shared filesystem with daemon.",
+                Config.DATA_DIR,
+                container_id,
+            )
+        except (docker.errors.NotFound, APIError, OSError) as e:
+            logger.debug(
+                "Could not auto-detect host DATA_DIR mapping (%s); assuming "
+                "no translation needed.",
+                e,
+            )
+
+        self._host_data_dir_cache = None
+        return None
+
+    def translate_to_host_path(self, container_path: str | os.PathLike) -> str:
+        """Translate a path inside DATA_DIR from app-container to host view.
+
+        If we're not running as a sibling container (or the path isn't under
+        DATA_DIR), the input is returned unchanged.
+        """
+        host_data_dir = self._detect_host_data_dir()
+        if host_data_dir is None:
+            return str(container_path)
+
+        try:
+            relative = Path(container_path).resolve().relative_to(
+                Path(Config.DATA_DIR).resolve()
+            )
+        except ValueError:
+            # Path isn't under DATA_DIR — leave it alone.
+            return str(container_path)
+
+        return str(host_data_dir / relative)
 
     def _check_docker_running(self) -> bool:
         """Check if the Docker daemon is running."""

--- a/src/mcp_anywhere/core/mcp_manager.py
+++ b/src/mcp_anywhere/core/mcp_manager.py
@@ -61,8 +61,12 @@ def create_mcp_config(server: "MCPServer") -> dict[str, dict[str, Any]]:
         file_manager = SecureFileManager()
         container_files = file_manager.prepare_container_files(server.id, secret_files)
 
-        for host_path, container_path in container_files.items():
-            volume_args.extend(["-v", f"{host_path}:{container_path}:ro"])
+        for source_path, container_path in container_files.items():
+            # If we're a sibling container talking to the host docker daemon,
+            # the daemon resolves bind sources against the host's filesystem,
+            # not ours — translate before passing to docker run.
+            host_source = container_manager.translate_to_host_path(source_path)
+            volume_args.extend(["-v", f"{host_source}:{container_path}:ro"])
 
     new_config = {
         "command": "docker",

--- a/tests/test_container_manager.py
+++ b/tests/test_container_manager.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 from docker.errors import APIError, ImageNotFound, NotFound
@@ -459,3 +461,122 @@ class TestMultipleContainers:
         assert tag1 != tag2
         assert "server-1" in tag1
         assert "server-2" in tag2
+
+
+class TestHostPathTranslation:
+    """Bind sources for spawned MCP servers must use host paths when MCP
+    Anywhere talks to a sibling docker daemon."""
+
+    def test_explicit_host_data_dir_override_wins(
+        self, container_manager, mock_docker_client
+    ):
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = "/mcp-anywhere-data"
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            translated = container_manager.translate_to_host_path(
+                "/app/.data/secrets/abc/temp_xyz.json"
+            )
+
+        assert translated == "/mcp-anywhere-data/secrets/abc/temp_xyz.json"
+        mock_docker_client.containers.get.assert_not_called()
+
+    def test_auto_detects_via_self_inspect(
+        self, container_manager, mock_docker_client
+    ):
+        mock_self_container = MagicMock()
+        mock_self_container.attrs = {
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/mcp-anywhere-data",
+                    "Destination": "/app/.data",
+                },
+                {
+                    "Type": "bind",
+                    "Source": "/var/run/docker.sock",
+                    "Destination": "/var/run/docker.sock",
+                },
+            ]
+        }
+        mock_docker_client.containers.get.return_value = mock_self_container
+
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = None
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            translated = container_manager.translate_to_host_path(
+                "/app/.data/secrets/abc/temp_xyz.json"
+            )
+
+        assert translated == "/mcp-anywhere-data/secrets/abc/temp_xyz.json"
+
+    def test_returns_path_unchanged_when_no_mapping_found(
+        self, container_manager, mock_docker_client
+    ):
+        mock_self_container = MagicMock()
+        mock_self_container.attrs = {"Mounts": []}
+        mock_docker_client.containers.get.return_value = mock_self_container
+
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = None
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            translated = container_manager.translate_to_host_path(
+                "/app/.data/secrets/abc/temp_xyz.json"
+            )
+
+        assert translated == "/app/.data/secrets/abc/temp_xyz.json"
+
+    def test_path_outside_data_dir_passes_through(
+        self, container_manager, mock_docker_client
+    ):
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = "/mcp-anywhere-data"
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            translated = container_manager.translate_to_host_path(
+                "/etc/something-else.json"
+            )
+
+        assert translated == "/etc/something-else.json"
+
+    def test_inspect_failure_falls_back_to_no_translation(
+        self, container_manager, mock_docker_client
+    ):
+        mock_docker_client.containers.get.side_effect = NotFound("nope")
+
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = None
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            translated = container_manager.translate_to_host_path(
+                "/app/.data/secrets/abc/temp_xyz.json"
+            )
+
+        assert translated == "/app/.data/secrets/abc/temp_xyz.json"
+
+    def test_result_is_cached(self, container_manager, mock_docker_client):
+        mock_self_container = MagicMock()
+        mock_self_container.attrs = {
+            "Mounts": [
+                {"Source": "/mcp-anywhere-data", "Destination": "/app/.data"},
+            ]
+        }
+        mock_docker_client.containers.get.return_value = mock_self_container
+
+        with patch("mcp_anywhere.container.manager.Config") as mock_cfg:
+            mock_cfg.HOST_DATA_DIR = None
+            mock_cfg.DATA_DIR = Path("/app/.data")
+            container_manager._host_data_dir_cache = "unset"
+
+            container_manager.translate_to_host_path("/app/.data/a")
+            container_manager.translate_to_host_path("/app/.data/b")
+            container_manager.translate_to_host_path("/app/.data/c")
+
+        assert mock_docker_client.containers.get.call_count == 1


### PR DESCRIPTION
## Summary

- When MCP Anywhere runs inside a container that talks to a sibling host docker daemon (i.e. `/var/run/docker.sock` bind-mounted from the host), the daemon resolves bind-mount sources against the **host's** filesystem, not the app container's. Secret files written under `/app/.data/secrets/` therefore weren't visible to the daemon under that path; legacy `-v` syntax auto-created empty directories at the missing source, and pydantic in the spawned MCP server correctly reported `path_not_file` because the destination really was a directory.
- `ContainerManager` now translates any `DATA_DIR`-rooted bind source from the app-container view to the host view before constructing `-v` args. Resolution order:
  1. `HOST_DATA_DIR` env var (escape hatch).
  2. Auto-detect by inspecting our own container's `Mounts` through the docker socket and matching `DATA_DIR` as the destination.
  3. Fall back to no translation. Correct for native deploys and DinD — in DinD the inner daemon doesn't know about the outer app container, so the lookup `NotFound`s and we cache `None`.
- Result is cached. Inspection failures fall through to no translation rather than crashing.

## Why this is a separate PR from #51

#51 added defensive checks (raise on missing encrypted file, refuse to mount a directory at the bind source, log the assembled `docker run` args) but didn't fix the root cause for sibling-container deploys. Diagnostic output from a real instance — `inspect .Mounts` showed `Source` pointing at `/app/.data/secrets/<id>/temp_*.json`, which `stat` confirmed was a regular file in the app container yet a directory inside the spawned MCP server — pinned the bug to a path-translation gap. This change closes that gap.

## Test plan

- [x] `uv run --python 3.12 pytest tests/test_container_manager.py::TestHostPathTranslation tests/test_secret_file_manager.py` passes (6 new translator tests + the 4 existing secret-file tests)
- [x] Existing `tests/test_container_manager.py` suite still passes (one pre-existing unrelated failure ignored)
- [ ] Reviewer to verify on the sibling-container prod stack: `docker compose exec app docker inspect mcp-<id> --format '{{json .Mounts}}'` now shows `Source` pointing at the **host** path (e.g. `/mcp-anywhere-data/secrets/<id>/temp_*.json`), and the MCP server starts cleanly
- [ ] Reviewer to verify on the local DinD stack (`docker-compose.yml`): bind sources stay as `/app/.data/...` and continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)