### PR TITLE
feat: add OAuth refresh token support with configurable token lifetimes

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,6 +9,13 @@ SECRET_KEY=your-secret-key-here-change-in-production
 # OAuth sessions will expire after this duration
 SESSION_MAX_AGE=28800
 
+# OAuth token lifetimes in seconds
+# Access tokens are short-lived; MCP clients renew them automatically
+# using the refresh_token grant without user interaction.
+# ACCESS_TOKEN_EXPIRES_IN=3600
+# Refresh token lifetime (default: 2592000 = 30 days, 0 = never expires)
+# REFRESH_TOKEN_EXPIRES_IN=2592000
+
 # JWT Configuration
 # Set a strong secret key for JWT token signing and verification
 # IMPORTANT: Generate a secure random key in production!

--- a/src/mcp_anywhere/auth/provider.py
+++ b/src/mcp_anywhere/auth/provider.py
@@ -746,7 +746,7 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
                 detail="Failed to fetch Google OAuth user profile"
             )
 
-        logger.debug(f"google user {http_response.json()["email"]}")
+        logger.debug(f"google user {http_response.json()['email']}")
 
         self.google_cache[g_token] = http_response.json()
 

--- a/src/mcp_anywhere/auth/provider.py
+++ b/src/mcp_anywhere/auth/provider.py
@@ -33,6 +33,19 @@ from mcp_anywhere.web.settings_routes import get_setting
 
 logger = get_logger(__name__)
 
+# Grant types supported by this authorization server
+SUPPORTED_GRANT_TYPES = ["authorization_code", "refresh_token"]
+
+
+def _refresh_token_expires_at() -> int | None:
+    """Compute the expiry timestamp for a newly issued refresh token.
+
+    Returns None (never expires) when REFRESH_TOKEN_EXPIRES_IN is 0.
+    """
+    if Config.REFRESH_TOKEN_EXPIRES_IN <= 0:
+        return None
+    return int(time.time()) + Config.REFRESH_TOKEN_EXPIRES_IN
+
 
 class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
     """OAuth 2.0 provider that integrates MCP SDK auth with our database with PKCE support."""
@@ -44,12 +57,17 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
         self.db_session_factory = db_session_factory
         self.auth_codes = {}  # In-memory storage for demo, use DB in production
         self.access_tokens = {}  # Token storage
+        # Refresh token storage (token string -> RefreshToken)
+        self.refresh_tokens: dict[str, RefreshToken] = {}
         # Add in-memory client cache for immediate availability (single-user system)
         self.client_cache: dict[str, OAuthClientInformationFull] = {}
         # Storage for OAuth requests during authorization flow
         self.oauth_requests: dict[str, dict[str, Any]] = {}
         # Map access tokens to user IDs for user-specific filtering
         self.token_users: dict[str, str] = {}
+        # Map refresh tokens to user IDs so refreshed access tokens keep
+        # their user association
+        self.refresh_token_users: dict[str, str] = {}
 
     async def create_authorization_code(
         self,
@@ -134,14 +152,36 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
         # The MCP SDK validates the code_verifier against the code_challenge before getting here
         # So we don't need to do PKCE validation again in the provider
 
-        # Generate access token
+        # Delete used authorization code
+        del self.auth_codes[code_string]
+
+        # Issue access + refresh token pair
+        return self._issue_token_pair(
+            client_id=client.client_id,
+            scopes=auth_code_data["scope"].split(),
+            user_id=auth_code_data["user_id"],
+        )
+
+    def _issue_token_pair(
+        self, client_id: str, scopes: list[str], user_id: str
+    ) -> OAuthToken:
+        """Issue a new access/refresh token pair and store them.
+
+        Args:
+            client_id: OAuth client the tokens are issued to
+            scopes: Scopes granted to the tokens
+            user_id: ID of the user the tokens act on behalf of
+
+        Returns:
+            OAuthToken response containing both tokens
+        """
         token = secrets.token_urlsafe(32)
-        expires_at = int(time.time() + 3600)  # 1 hour
+        expires_at = int(time.time()) + Config.ACCESS_TOKEN_EXPIRES_IN
 
         access_token = AccessToken(
             token=token,
-            client_id=client.client_id,
-            scopes=auth_code_data["scope"].split(),
+            client_id=client_id,
+            scopes=scopes,
             expires_at=expires_at,
             resource=f"{Config.SERVER_URL}{Config.MCP_PATH_PREFIX}",
         )
@@ -150,17 +190,26 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
         self.access_tokens[token] = access_token
 
         # Store user_id mapping for this token
-        self.token_users[token] = auth_code_data["user_id"]
+        self.token_users[token] = user_id
 
-        # Delete used authorization code
-        del self.auth_codes[code_string]
+        # Issue refresh token so clients can renew access without
+        # re-running the interactive authorization flow
+        refresh_token_str = secrets.token_urlsafe(32)
+        self.refresh_tokens[refresh_token_str] = RefreshToken(
+            token=refresh_token_str,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=_refresh_token_expires_at(),
+        )
+        self.refresh_token_users[refresh_token_str] = user_id
 
         # Return OAuthToken for MCP SDK compatibility
         return OAuthToken(
             access_token=token,
             token_type="Bearer",
-            expires_in=3600,
-            scope=" ".join(access_token.scopes),
+            expires_in=Config.ACCESS_TOKEN_EXPIRES_IN,
+            scope=" ".join(scopes),
+            refresh_token=refresh_token_str,
         )
 
     async def introspect_token(self, token: str) -> AccessToken | None:
@@ -185,14 +234,19 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
     async def revoke_token(
         self, token: str, token_type_hint: str | None = None
     ) -> bool:
-        """Revoke an access token."""
+        """Revoke an access or refresh token."""
+        revoked = False
         if token in self.access_tokens:
             del self.access_tokens[token]
             # Clean up user mapping
             if token in self.token_users:
                 del self.token_users[token]
-            return True
-        return False
+            revoked = True
+        if token in self.refresh_tokens:
+            del self.refresh_tokens[token]
+            self.refresh_token_users.pop(token, None)
+            revoked = True
+        return revoked
 
     def get_user_id_from_token(self, token: str) -> str | None:
         """Get the user_id associated with an access token.
@@ -232,6 +286,16 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
                 return None
 
             # Convert database model to MCP SDK model and cache it
+            grant_types = (
+                db_client.grant_types.split()
+                if db_client.grant_types
+                else list(SUPPORTED_GRANT_TYPES)
+            )
+            # Clients registered before refresh token support may have been
+            # stored with the bare default; allow them to refresh as well.
+            if grant_types == ["authorization_code"]:
+                grant_types = list(SUPPORTED_GRANT_TYPES)
+
             client_info = OAuthClientInformationFull(
                 client_id=db_client.client_id,
                 client_secret=(
@@ -239,7 +303,7 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
                 ),
                 client_name=db_client.client_name,
                 redirect_uris=[db_client.redirect_uri],
-                grant_types=["authorization_code"],
+                grant_types=grant_types,
                 response_types=["code"],
                 scope=db_client.scope,
             )
@@ -341,28 +405,74 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
             refresh_token: The refresh token to look up
 
         Returns:
-            RefreshToken object if found, None otherwise
+            RefreshToken object if found and valid, None otherwise
         """
-        # We don't currently support refresh tokens in this implementation
-        return None
+        token_data = self.refresh_tokens.get(refresh_token)
+        if not token_data:
+            return None
+
+        # Refresh tokens are bound to the client they were issued to
+        if token_data.client_id != client.client_id:
+            logger.warning(
+                f"Refresh token client mismatch: issued to {token_data.client_id}, "
+                f"presented by {client.client_id}"
+            )
+            return None
+
+        # Drop expired refresh tokens
+        if token_data.expires_at is not None and time.time() > token_data.expires_at:
+            del self.refresh_tokens[refresh_token]
+            self.refresh_token_users.pop(refresh_token, None)
+            return None
+
+        return token_data
 
     async def exchange_refresh_token(
-        self, client: OAuthClientInformationFull, refresh_token: RefreshToken
-    ) -> AccessToken:
-        """Exchange refresh token for new access token.
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        """Exchange refresh token for a new access/refresh token pair.
+
+        Implements refresh token rotation (OAuth 2.1): the presented refresh
+        token is invalidated and a new one is returned with the new access
+        token.
 
         Args:
             client: The OAuth client
             refresh_token: The refresh token to exchange
+            scopes: Requested scopes (already validated by the MCP SDK token
+                handler to be a subset of the refresh token's scopes)
 
         Returns:
-            New AccessToken
+            OAuthToken response with a new access and refresh token
 
         Raises:
             TokenError: If refresh token is invalid
         """
-        # We don't currently support refresh tokens in this implementation
-        raise TokenError("unsupported_grant_type")
+        token_str = refresh_token.token
+        if token_str not in self.refresh_tokens:
+            raise TokenError("invalid_grant")
+
+        user_id = self.refresh_token_users.get(token_str)
+        if user_id is None:
+            # Mapping lost (e.g. inconsistent state) - treat as invalid
+            del self.refresh_tokens[token_str]
+            raise TokenError("invalid_grant")
+
+        # Rotate: invalidate the presented refresh token
+        del self.refresh_tokens[token_str]
+        del self.refresh_token_users[token_str]
+
+        new_scopes = scopes or refresh_token.scopes
+
+        logger.info(f"Refreshed tokens for client {client.client_id}")
+        return self._issue_token_pair(
+            client_id=client.client_id,
+            scopes=new_scopes,
+            user_id=user_id,
+        )
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         """Register a new OAuth client.
@@ -385,6 +495,7 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
         client_name = client_info.client_name or "Unknown Client"
         redirect_uris = [str(url) for url in (client_info.redirect_uris or [])]
         scope = client_info.scope or "mcp:read mcp:write"
+        grant_types = " ".join(client_info.grant_types or SUPPORTED_GRANT_TYPES)
 
         # Determine if client is confidential (has a secret)
         is_confidential = client_secret is not None
@@ -396,6 +507,7 @@ class MCPAnywhereAuthProvider(OAuthAuthorizationServerProvider):
                 client_name=client_name,
                 redirect_uri=redirect_uris[0] if redirect_uris else "",
                 scope=scope,
+                grant_types=grant_types,
                 is_confidential=is_confidential,
             )
             session.add(client)
@@ -411,11 +523,19 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
         self.clients: dict[str, OAuthClientInformationFull] = {}
         self.auth_codes: dict[str, AuthorizationCode] = {}
         self.tokens: dict[str, AccessToken] = {}
+        # Refresh token storage (token string -> RefreshToken)
+        self.refresh_tokens: dict[str, RefreshToken] = {}
         self.state_mapping: dict[str, dict[str, str]] = {}
         self.g_token_mapping: dict[str, str] = {}
         self.state_resource_tokens: dict[str] = {}
         # Map access tokens to user IDs for user-specific filtering
         self.token_users: dict[str, str] = {}
+        # Map refresh tokens to user IDs so refreshed access tokens keep
+        # their user association
+        self.refresh_token_users: dict[str, str] = {}
+        # Map refresh tokens to the underlying Google token so refreshed
+        # access tokens keep working with get_google_token_for_token
+        self.refresh_token_g_tokens: dict[str, str] = {}
         # Map authorization codes to user profiles for user lookup and creation
         self.code_user_profiles: dict[str, dict[str, Any]] = {}
         self.google_cache: dict[str, dict[str, Any]] = {}
@@ -593,7 +713,7 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
             token=mcp_token,
             client_id=client.client_id,
             scopes=authorization_code.scopes,
-            expires_at=int(time.time()) + 3600,
+            expires_at=int(time.time()) + Config.ACCESS_TOKEN_EXPIRES_IN,
         )
 
         google_token = next(
@@ -649,11 +769,27 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
 
         del self.auth_codes[authorization_code.code]
 
+        # Issue refresh token so clients can renew access without
+        # re-running the interactive Google authorization flow
+        refresh_token_str = secrets.token_hex(32)
+        self.refresh_tokens[refresh_token_str] = RefreshToken(
+            token=refresh_token_str,
+            client_id=client.client_id,
+            scopes=authorization_code.scopes,
+            expires_at=_refresh_token_expires_at(),
+        )
+        user_id = self.token_users.get(mcp_token)
+        if user_id is not None:
+            self.refresh_token_users[refresh_token_str] = user_id
+        if google_token:
+            self.refresh_token_g_tokens[refresh_token_str] = google_token
+
         return OAuthToken(
             access_token=mcp_token,
             token_type="bearer",
-            expires_in=3600,
+            expires_in=Config.ACCESS_TOKEN_EXPIRES_IN,
             scope=" ".join(authorization_code.scopes),
+            refresh_token=refresh_token_str,
         )
 
     async def load_access_token(self, token: str) -> AccessToken | None:
@@ -673,8 +809,25 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
         return access_token
 
     async def load_refresh_token(self, client: OAuthClientInformationFull, refresh_token: str) -> RefreshToken | None:
-        """Load a refresh token - not supported."""
-        return None
+        """Load a refresh token."""
+        token_data = self.refresh_tokens.get(refresh_token)
+        if not token_data:
+            return None
+
+        # Refresh tokens are bound to the client they were issued to
+        if token_data.client_id != client.client_id:
+            logger.warning(
+                f"Refresh token client mismatch: issued to {token_data.client_id}, "
+                f"presented by {client.client_id}"
+            )
+            return None
+
+        # Drop expired refresh tokens
+        if token_data.expires_at is not None and time.time() > token_data.expires_at:
+            self._discard_refresh_token(refresh_token)
+            return None
+
+        return token_data
 
     async def exchange_refresh_token(
             self,
@@ -682,16 +835,73 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
             refresh_token: RefreshToken,
             scopes: list[str],
     ) -> OAuthToken:
-        """Exchange refresh token"""
-        raise NotImplementedError("Not supported")
+        """Exchange refresh token for a new access/refresh token pair.
+
+        Implements refresh token rotation (OAuth 2.1): the presented refresh
+        token is invalidated and a new one is returned with the new access
+        token.
+        """
+        token_str = refresh_token.token
+        if token_str not in self.refresh_tokens:
+            raise TokenError("invalid_grant")
+
+        user_id = self.refresh_token_users.get(token_str)
+        google_token = self.refresh_token_g_tokens.get(token_str)
+
+        # Rotate: invalidate the presented refresh token
+        self._discard_refresh_token(token_str)
+
+        new_scopes = scopes or refresh_token.scopes
+
+        mcp_token = secrets.token_hex(32)
+        self.tokens[mcp_token] = AccessToken(
+            token=mcp_token,
+            client_id=client.client_id,
+            scopes=new_scopes,
+            expires_at=int(time.time()) + Config.ACCESS_TOKEN_EXPIRES_IN,
+        )
+
+        if user_id is not None:
+            self.token_users[mcp_token] = user_id
+        if google_token:
+            self.g_token_mapping[mcp_token] = google_token
+
+        new_refresh_token = secrets.token_hex(32)
+        self.refresh_tokens[new_refresh_token] = RefreshToken(
+            token=new_refresh_token,
+            client_id=client.client_id,
+            scopes=new_scopes,
+            expires_at=_refresh_token_expires_at(),
+        )
+        if user_id is not None:
+            self.refresh_token_users[new_refresh_token] = user_id
+        if google_token:
+            self.refresh_token_g_tokens[new_refresh_token] = google_token
+
+        logger.info(f"Refreshed tokens for client {client.client_id}")
+        return OAuthToken(
+            access_token=mcp_token,
+            token_type="bearer",
+            expires_in=Config.ACCESS_TOKEN_EXPIRES_IN,
+            scope=" ".join(new_scopes),
+            refresh_token=new_refresh_token,
+        )
+
+    def _discard_refresh_token(self, token_str: str) -> None:
+        """Remove a refresh token and its associated mappings."""
+        self.refresh_tokens.pop(token_str, None)
+        self.refresh_token_users.pop(token_str, None)
+        self.refresh_token_g_tokens.pop(token_str, None)
 
     async def revoke_token(self, token: str, token_type_hint: str | None = None) -> None:
-        """Revoke a token."""
+        """Revoke an access or refresh token."""
         if token in self.tokens:
             del self.tokens[token]
             # Clean up user mapping
             if token in self.token_users:
                 del self.token_users[token]
+        if token in self.refresh_tokens:
+            self._discard_refresh_token(token)
 
     async def introspect_token(self, token: str) -> AccessToken | None:
         """Introspect an access token for resource server validation.
@@ -705,8 +915,8 @@ class GoogleOAuthProvider(OAuthAuthorizationServerProvider):
         if not access_token:
             return None
 
-        # Check expiration
-        if time.time() > access_token.expires_at:
+        # Check expiration (Google resource tokens are stored without expiry)
+        if access_token.expires_at is not None and time.time() > access_token.expires_at:
             del self.tokens[token]
             # Clean up user mapping
             if token in self.token_users:

--- a/src/mcp_anywhere/auth/routes.py
+++ b/src/mcp_anywhere/auth/routes.py
@@ -214,8 +214,8 @@ async def handle_oauth_callback_btn(request: Request) -> RedirectResponse:
         user_profile = await oauth_provider.get_user_profile(access_token)
 
         if not await oauth_provider.user_has_domain_authorization(user_profile["email"]):
-            logger.error(f"User {user_profile["email"]} not part of authorized domain")
-            error_url = f"/auth/login?error=User {user_profile["email"]} not part of authorized domain"
+            logger.error(f"User {user_profile['email']} not part of authorized domain")
+            error_url = f"/auth/login?error=User {user_profile['email']} not part of authorized domain"
             if next_url != "/":
                 error_url += f"&next={next_url}"
             return RedirectResponse(url=error_url, status_code=302)
@@ -228,7 +228,7 @@ async def handle_oauth_callback_btn(request: Request) -> RedirectResponse:
             "role": google_user.role,
         })
 
-        logger.debug(f"Google User {user_profile["email"]} authenticated, redirecting to {next_url}")
+        logger.debug(f"Google User {user_profile['email']} authenticated, redirecting to {next_url}")
 
         return RedirectResponse(status_code=302, url=next_url)
     except HTTPException:

--- a/src/mcp_anywhere/config.py
+++ b/src/mcp_anywhere/config.py
@@ -57,6 +57,18 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "dev-secret-key-change-in-production")
     SESSION_MAX_AGE = int(os.environ.get("SESSION_MAX_AGE", "28800"))  # 8 hours default
 
+    # OAuth token lifetimes (seconds)
+    # Access tokens are short-lived; clients obtain new ones silently via the
+    # refresh_token grant, so MCP clients no longer need to re-run the
+    # interactive OAuth flow every time an access token expires.
+    ACCESS_TOKEN_EXPIRES_IN = int(
+        os.environ.get("ACCESS_TOKEN_EXPIRES_IN", "3600")
+    )  # 1 hour default
+    # Set to 0 to issue non-expiring refresh tokens.
+    REFRESH_TOKEN_EXPIRES_IN = int(
+        os.environ.get("REFRESH_TOKEN_EXPIRES_IN", "2592000")
+    )  # 30 days default
+
     # Server settings
     DEFAULT_HOST = os.environ.get("DEFAULT_HOST", "0.0.0.0")
     DEFAULT_PORT = int(os.environ.get("DEFAULT_PORT", "8000"))

--- a/tests/test_refresh_tokens.py
+++ b/tests/test_refresh_tokens.py
@@ -1,0 +1,345 @@
+"""Tests for OAuth refresh token support in both auth providers."""
+
+import secrets
+import time
+
+import pytest
+from mcp.server.auth.provider import (
+    AuthorizationCode,
+    OAuthClientInformationFull,
+    RefreshToken,
+    TokenError,
+)
+from pydantic import AnyHttpUrl
+
+from mcp_anywhere.auth.models import OAuth2Client
+from mcp_anywhere.auth.provider import (
+    SUPPORTED_GRANT_TYPES,
+    GoogleOAuthProvider,
+    MCPAnywhereAuthProvider,
+)
+from mcp_anywhere.config import Config
+
+REDIRECT_URI = "http://localhost/callback"
+
+
+def _make_client_info(client_id: str = "test_client") -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret="test_secret",
+        client_name="Test Client",
+        redirect_uris=[AnyHttpUrl(REDIRECT_URI)],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope="mcp:read mcp:write",
+    )
+
+
+async def _authorize_and_exchange(provider, client_info, db_session=None):
+    """Run the authorization-code part of the flow and return the token response."""
+    code = await provider.create_authorization_code(
+        request=None,
+        client_id=client_info.client_id,
+        redirect_uri=REDIRECT_URI,
+        user_id="42",
+        code_challenge="test_challenge",
+        code_challenge_method="S256",
+        scopes=["mcp:read"],
+    )
+    auth_code = await provider.load_authorization_code(client_info, code)
+    return await provider.exchange_authorization_code(client_info, auth_code)
+
+
+@pytest.mark.asyncio
+async def test_exchange_authorization_code_returns_refresh_token(db_session):
+    """Token response must include a refresh token alongside the access token."""
+
+    def session_factory():
+        return db_session
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    token = await _authorize_and_exchange(provider, client_info)
+
+    assert token.access_token
+    assert token.refresh_token, "Token response should include a refresh token"
+    assert token.expires_in == Config.ACCESS_TOKEN_EXPIRES_IN
+
+    # Refresh token is stored and bound to the client and user
+    stored = provider.refresh_tokens[token.refresh_token]
+    assert stored.client_id == client_info.client_id
+    assert stored.scopes == ["mcp:read"]
+    assert provider.refresh_token_users[token.refresh_token] == "42"
+
+
+@pytest.mark.asyncio
+async def test_load_refresh_token_validates_client_and_expiry(db_session):
+    """load_refresh_token returns the token only for the issuing client."""
+
+    def session_factory():
+        return db_session
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    token = await _authorize_and_exchange(provider, client_info)
+
+    # Valid lookup
+    loaded = await provider.load_refresh_token(client_info, token.refresh_token)
+    assert loaded is not None
+    assert loaded.token == token.refresh_token
+
+    # Unknown token
+    assert await provider.load_refresh_token(client_info, "missing") is None
+
+    # Wrong client
+    other_client = _make_client_info(client_id="other_client")
+    assert await provider.load_refresh_token(other_client, token.refresh_token) is None
+
+    # Expired refresh token is dropped
+    expired = RefreshToken(
+        token="expired-token",
+        client_id=client_info.client_id,
+        scopes=["mcp:read"],
+        expires_at=int(time.time()) - 10,
+    )
+    provider.refresh_tokens["expired-token"] = expired
+    provider.refresh_token_users["expired-token"] = "42"
+    assert await provider.load_refresh_token(client_info, "expired-token") is None
+    assert "expired-token" not in provider.refresh_tokens
+    assert "expired-token" not in provider.refresh_token_users
+
+
+@pytest.mark.asyncio
+async def test_exchange_refresh_token_rotates_and_preserves_user(db_session):
+    """Refreshing returns a new token pair and invalidates the old refresh token."""
+
+    def session_factory():
+        return db_session
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    token = await _authorize_and_exchange(provider, client_info)
+    old_refresh = token.refresh_token
+
+    loaded = await provider.load_refresh_token(client_info, old_refresh)
+    new_token = await provider.exchange_refresh_token(
+        client_info, loaded, loaded.scopes
+    )
+
+    # New pair issued
+    assert new_token.access_token != token.access_token
+    assert new_token.refresh_token != old_refresh
+    assert new_token.expires_in == Config.ACCESS_TOKEN_EXPIRES_IN
+
+    # New access token is valid and keeps the user association
+    access = await provider.load_access_token(new_token.access_token)
+    assert access is not None
+    assert provider.get_user_id_from_token(new_token.access_token) == "42"
+
+    # Rotation: old refresh token no longer usable
+    assert old_refresh not in provider.refresh_tokens
+    assert await provider.load_refresh_token(client_info, old_refresh) is None
+    with pytest.raises(TokenError):
+        await provider.exchange_refresh_token(
+            client_info,
+            RefreshToken(
+                token=old_refresh,
+                client_id=client_info.client_id,
+                scopes=["mcp:read"],
+            ),
+            ["mcp:read"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_handles_refresh_tokens(db_session):
+    """Revocation endpoint should also revoke refresh tokens."""
+
+    def session_factory():
+        return db_session
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    token = await _authorize_and_exchange(provider, client_info)
+
+    assert await provider.revoke_token(token.refresh_token) is True
+    assert token.refresh_token not in provider.refresh_tokens
+    assert await provider.load_refresh_token(client_info, token.refresh_token) is None
+
+    # Access token revocation still works
+    assert await provider.revoke_token(token.access_token) is True
+    assert await provider.revoke_token("unknown-token") is False
+
+
+@pytest.mark.asyncio
+async def test_get_client_includes_refresh_token_grant(db_session):
+    """Clients loaded from the database may use the refresh_token grant.
+
+    The MCP SDK token handler rejects grants not listed in the client's
+    grant_types, so get_client must include refresh_token for clients
+    registered before refresh token support existed.
+    """
+
+    def session_factory():
+        return db_session
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+
+    # Simulate a client registered before refresh token support
+    legacy = OAuth2Client(
+        client_id="legacy_client",
+        client_secret="secret",
+        client_name="Legacy",
+        redirect_uri=REDIRECT_URI,
+        scope="mcp:read",
+        grant_types="authorization_code",
+    )
+    db_session.add(legacy)
+    await db_session.commit()
+
+    client_info = await provider.get_client("legacy_client")
+    assert client_info is not None
+    assert "refresh_token" in client_info.grant_types
+
+    # Newly registered clients persist their grant types
+    new_client = _make_client_info(client_id="new_client")
+    await provider.register_client(new_client)
+    provider.client_cache.clear()  # force DB read
+    reloaded = await provider.get_client("new_client")
+    assert reloaded is not None
+    assert set(SUPPORTED_GRANT_TYPES).issubset(set(reloaded.grant_types))
+
+
+@pytest.mark.asyncio
+async def test_token_lifetimes_use_config(db_session, monkeypatch):
+    """Access and refresh token lifetimes come from configuration."""
+
+    def session_factory():
+        return db_session
+
+    monkeypatch.setattr(Config, "ACCESS_TOKEN_EXPIRES_IN", 7200)
+    monkeypatch.setattr(Config, "REFRESH_TOKEN_EXPIRES_IN", 86400)
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    before = int(time.time())
+    token = await _authorize_and_exchange(provider, client_info)
+
+    assert token.expires_in == 7200
+    access = provider.access_tokens[token.access_token]
+    assert before + 7200 <= access.expires_at <= int(time.time()) + 7200
+
+    refresh = provider.refresh_tokens[token.refresh_token]
+    assert before + 86400 <= refresh.expires_at <= int(time.time()) + 86400
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_never_expires_when_configured(db_session, monkeypatch):
+    """REFRESH_TOKEN_EXPIRES_IN=0 issues non-expiring refresh tokens."""
+
+    def session_factory():
+        return db_session
+
+    monkeypatch.setattr(Config, "REFRESH_TOKEN_EXPIRES_IN", 0)
+
+    provider = MCPAnywhereAuthProvider(session_factory)
+    client_info = _make_client_info()
+    provider.client_cache[client_info.client_id] = client_info
+
+    token = await _authorize_and_exchange(provider, client_info)
+
+    refresh = provider.refresh_tokens[token.refresh_token]
+    assert refresh.expires_at is None
+    assert await provider.load_refresh_token(client_info, token.refresh_token) is not None
+
+
+@pytest.mark.asyncio
+async def test_google_provider_issues_and_rotates_refresh_tokens(db_session):
+    """Google provider issues refresh tokens and preserves user/Google mappings."""
+
+    def session_factory():
+        return db_session
+
+    provider = GoogleOAuthProvider(session_factory)
+    client_info = _make_client_info()
+    await provider.register_client(client_info)
+
+    # Authorization code with an auto-registered user profile
+    auth_code_str = secrets.token_hex(16)
+    auth_code = AuthorizationCode(
+        code=auth_code_str,
+        client_id=client_info.client_id,
+        redirect_uri=AnyHttpUrl(REDIRECT_URI),
+        redirect_uri_provided_explicitly=True,
+        expires_at=time.time() + 300,
+        scopes=["mcp:read"],
+        code_challenge="test_challenge",
+    )
+    provider.auth_codes[auth_code_str] = auth_code
+    provider.code_user_profiles[auth_code_str] = {
+        "email": "refresh@example.com",
+        "given_name": "Refresh",
+    }
+
+    token = await provider.exchange_authorization_code(client_info, auth_code)
+
+    assert token.refresh_token, "Google provider should issue a refresh token"
+    user_id = provider.get_user_id_from_token(token.access_token)
+    assert user_id is not None
+    assert provider.refresh_token_users[token.refresh_token] == user_id
+
+    # Simulate the Google token mapping that handle_callback would create
+    provider.refresh_token_g_tokens[token.refresh_token] = "google-token-123"
+
+    loaded = await provider.load_refresh_token(client_info, token.refresh_token)
+    assert loaded is not None
+
+    new_token = await provider.exchange_refresh_token(
+        client_info, loaded, loaded.scopes
+    )
+
+    # New pair issued; user and Google token mappings preserved
+    assert new_token.access_token != token.access_token
+    assert new_token.refresh_token != token.refresh_token
+    assert provider.get_user_id_from_token(new_token.access_token) == user_id
+    assert provider.g_token_mapping[new_token.access_token] == "google-token-123"
+    assert (
+        provider.refresh_token_g_tokens[new_token.refresh_token] == "google-token-123"
+    )
+
+    # Rotation: old refresh token invalidated
+    assert token.refresh_token not in provider.refresh_tokens
+    assert await provider.load_refresh_token(client_info, token.refresh_token) is None
+    with pytest.raises(TokenError):
+        await provider.exchange_refresh_token(client_info, loaded, loaded.scopes)
+
+
+@pytest.mark.asyncio
+async def test_google_introspect_token_handles_no_expiry(db_session):
+    """Google resource tokens are stored without expiry and must not crash."""
+    from mcp.server.auth.provider import AccessToken
+
+    def session_factory():
+        return db_session
+
+    provider = GoogleOAuthProvider(session_factory)
+    provider.tokens["google-raw-token"] = AccessToken(
+        token="google-raw-token",
+        client_id="test_client",
+        scopes=["mcp:read"],
+        expires_at=None,
+    )
+
+    result = await provider.introspect_token("google-raw-token")
+    assert result is not None
+    assert result.token == "google-raw-token"


### PR DESCRIPTION
## Problem

MCP clients currently have to re-run the full interactive OAuth flow every time an access token expires, because:

- Access token lifetime is hardcoded to 3600s in both providers
- `exchange_refresh_token` raises `unsupported_grant_type` / `NotImplementedError` and `load_refresh_token` returns `None`, so the `refresh_token` grant is unusable
- `get_client` hardcodes `grant_types=["authorization_code"]`, so the MCP SDK token handler would reject refresh grants even if they were implemented

For agent-style usage (several MCP clients connected to one gateway) this means every client needs a human to click through the consent flow again every hour.

## Changes

- Implement `load_refresh_token` / `exchange_refresh_token` in `MCPAnywhereAuthProvider` and `GoogleOAuthProvider` with refresh token rotation (OAuth 2.1): each refresh invalidates the presented refresh token and issues a new access/refresh pair
- Preserve the user-id mapping (and Google token mapping in `GoogleOAuthProvider`) across refreshes so user-specific tool filtering keeps working
- Fix the `exchange_refresh_token` signature to match the MCP SDK token handler (`client, refresh_token, scopes`) - the old signature would have raised `TypeError` if the handler ever reached it
- Persist client `grant_types` on registration and stop hardcoding `["authorization_code"]` in `get_client`; clients stored before this change are upgraded to include `refresh_token` on load
- Make token lifetimes configurable: `ACCESS_TOKEN_EXPIRES_IN` (default 3600s - unchanged behaviour) and `REFRESH_TOKEN_EXPIRES_IN` (default 30 days, `0` = never expires), documented in `env.example`
- Support refresh token revocation through the existing revocation endpoint
- Guard `GoogleOAuthProvider.introspect_token` against tokens stored without expiry (Google resource tokens are stored with `expires_at=None` and previously crashed the comparison)
- First commit fixes PEP 701 f-strings (Python 3.12-only syntax) since `pyproject.toml` declares `requires-python >= 3.11`

## Notes

- Defaults are backwards compatible: access tokens still last 1 hour; the behavioural change is that token responses now include a `refresh_token`, which spec-compliant clients use automatically to renew access without user interaction
- Tokens remain in-memory (existing design), so refresh tokens do not survive a restart. Persisting them via the existing-but-unused `OAuth2RefreshToken` model would be a natural follow-up - happy to tackle that here or separately if you prefer
- Scope narrowing on refresh is validated by the MCP SDK token handler; the provider honours the requested subset

## Testing

- 9 new tests in `tests/test_refresh_tokens.py`: refresh token issuance, client binding, expiry, rotation, revocation, configurable lifetimes, Google provider user/Google-token mapping preservation, and the no-expiry introspection guard
- Full suite run locally: no new failures vs. the base commit (pre-existing failures are unrelated - e.g. tests requiring `ANTHROPIC_API_KEY` and the asyncio shutdown tests)
