### PR TITLE
feat: persistent per-server /data volume for stateful MCP servers

### DIFF
--- a/src/mcp_anywhere/core/mcp_manager.py
+++ b/src/mcp_anywhere/core/mcp_manager.py
@@ -1,9 +1,11 @@
 """MCP Manager for handling dynamic server mounting and unmounting."""
 
+from pathlib import Path
 from typing import Any
 
 from fastmcp import FastMCP
 
+from mcp_anywhere.config import Config
 from mcp_anywhere.container.manager import ContainerManager
 from mcp_anywhere.database import MCPServer
 from mcp_anywhere.logging_config import get_logger
@@ -67,6 +69,19 @@ def create_mcp_config(server: "MCPServer") -> dict[str, dict[str, Any]]:
             # not ours — translate before passing to docker run.
             host_source = container_manager.translate_to_host_path(source_path)
             volume_args.extend(["-v", f"{host_source}:{container_path}:ro"])
+
+    # Persistent, writable per-server data directory.
+    # mcp-anywhere spawns each server as a fresh sibling container, so anything
+    # written inside the container's own filesystem is lost when the container
+    # is rebuilt or recreated (on restart, or with CLEANUP_CONTAINERS_ON_SHUTDOWN).
+    # Bind-mount a per-server directory that lives under DATA_DIR (the app's
+    # persistent volume) at /data (read-write), so servers can keep state across
+    # rebuilds — for example OAuth/MSAL token caches. translate_to_host_path maps
+    # the source to the host path when running as a sibling container.
+    persist_dir = Path(Config.DATA_DIR) / "server-data" / server.id
+    persist_dir.mkdir(parents=True, exist_ok=True)
+    host_persist_dir = container_manager.translate_to_host_path(str(persist_dir))
+    volume_args.extend(["-v", f"{host_persist_dir}:/data:rw"])
 
     new_config = {
         "command": "docker",


### PR DESCRIPTION
## Summary

MCP Anywhere spawns each MCP server as a fresh sibling container, so anything a server writes to its own container filesystem is lost whenever the container is rebuilt or recreated (on restart, or with `CLEANUP_CONTAINERS_ON_SHUTDOWN`). Today the only bind mounts into a server container are read-only secret files.

This adds a **persistent, writable per-server data directory**: a directory under `DATA_DIR` (the app's persistent volume) is bind-mounted into every server container at `/data` (read-write). Servers can now keep state across rebuilds.

The motivating case is delegated-OAuth servers such as [`@softeria/ms-365-mcp-server`](https://github.com/softeria/ms-365-mcp-server), whose MSAL token cache must survive container rebuilds — otherwise every rebuild silently logs the user out. Pointing `MS365_MCP_TOKEN_CACHE_PATH=/data/.token-cache.json` now Just Works. `mcp-python-interpreter` (which already starts with `--dir /data/python-sandbox`) also gains a persistent sandbox.

## Changes

- `core/mcp_manager.py`: in `create_mcp_config`, create `DATA_DIR/server-data/<server_id>` and append `-v <host_path>:/data:rw` to the `docker run` args. Reuses the existing `translate_to_host_path()` so the bind source is correctly mapped to the host path in sibling-container deployments (and is a no-op for native/DinD).

## Notes

- Per-server directory → no cross-server collisions.
- Lives under the existing persistent volume, so no new mounts or config are required.
- Backwards compatible: servers that don't use `/data` simply get an empty writable dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
