### PR TITLE
Add Labels to Dockerfiles used to build mcp containers

### DIFF
--- a/src/mcp_anywhere/dockerfiles/javascript/Dockerfile
+++ b/src/mcp_anywhere/dockerfiles/javascript/Dockerfile
@@ -1,1 +1,3 @@
 FROM node:20-slim
+
+LABEL org.opencontainers.image.source="https://github.com/locomotive-agency/mcp-anywhere"

--- a/src/mcp_anywhere/dockerfiles/python/Dockerfile
+++ b/src/mcp_anywhere/dockerfiles/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim
 
+LABEL org.opencontainers.image.source="https://github.com/locomotive-agency/mcp-anywhere"
+
 # Install additional system packages
 RUN apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
Keeping all the `Dockerfiles` consistent 